### PR TITLE
fix: content-type for svg

### DIFF
--- a/src/main/java/com/seiama/javaducks/controller/JavadocController.java
+++ b/src/main/java/com/seiama/javaducks/controller/JavadocController.java
@@ -67,7 +67,8 @@ public class JavadocController {
     ".css", MediaType.parseMediaType("text/css"),
     ".js", MediaType.parseMediaType("application/javascript"),
     ".zip", MediaType.parseMediaType("application/zip"),
-    ".html", MediaType.parseMediaType("text/html")
+    ".html", MediaType.parseMediaType("text/html"),
+    ".svg", MediaType.parseMediaType("image/svg+xml")
   );
   private final JavadocService service;
   private final JavadocInjector injector;


### PR DESCRIPTION
~~This may fix it, but it also may not. Locally it works
https://jd.papermc.io/paper/1.21/link.svg currently returns content-type: image/avif~~

~~no work yet~~

ok it might actually work maybe browser cache?

https://jd.mizule.dev/protocollib/5.3.0/com/comphenix/protocol/AsynchronousManager.html#method-summary
https://jd.mizule.dev/protocollib/5.3.0/link.svg