### PR TITLE
make it a cannon link

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -160,4 +160,7 @@ tasks {
   checkstyleAotTest {
     isEnabled = false
   }
+  bootRun {
+    workingDir = file("run")
+  }
 }

--- a/src/main/java/com/seiama/javaducks/configuration/properties/AppConfiguration.java
+++ b/src/main/java/com/seiama/javaducks/configuration/properties/AppConfiguration.java
@@ -36,6 +36,7 @@ import org.springframework.boot.context.properties.bind.DefaultValue;
 @NullMarked
 public record AppConfiguration(
   URI rootRedirect,
+  URI hostName,
   Path storage,
   List<EndpointConfiguration> endpoints,
   @DefaultValue({"SHA256", "SHA1"})

--- a/src/test/java/com/seiama/javaducks/controller/JavadocControllerTest.java
+++ b/src/test/java/com/seiama/javaducks/controller/JavadocControllerTest.java
@@ -83,7 +83,7 @@ public class JavadocControllerTest {
   void testRedirect() throws Exception {
     this.mockMvc.perform(get("/paper/1.20/"))
       .andExpect(status().isFound())
-      .andExpect(redirectedUrl("/paper/1.20.4/"));
+      .andExpect(redirectedUrl("/paper/1.20.6/"));
   }
 
   @Test
@@ -122,7 +122,7 @@ public class JavadocControllerTest {
   void testOutdatedBannerInjection() throws Exception {
     this.mockMvc.perform(get("/paper/1.12/overview-summary.html"))
       .andExpect(status().isOk())
-      .andExpect(content().string(containsString("location.href.replace('paper/1.12/', 'paper/1.20.4/')")));
+      .andExpect(content().string(containsString("location.href.replace('paper/1.12/', 'paper/1.21/')")));
   }
 
   @Test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,5 +1,6 @@
 app:
   root-redirect: 'https://papermc.io/javadocs'
+  host-name: 'https://jd.papermc.io'
   storage: './build/tmp/work'
   endpoints:
     - name: 'paper'
@@ -8,10 +9,16 @@ app:
           path: 'https://repo.papermc.io/repository/maven-public/com/destroystokyo/paper/paper-api/1.12.2-R0.1-SNAPSHOT/'
           type: 'SNAPSHOT'
         - name: '1.20'
-          path: '/paper/1.20.4/'
+          path: '/paper/1.20.6/'
           type: 'REDIRECT'
         - name: '1.20.4'
           path: 'https://repo.papermc.io/repository/maven-public/io/papermc/paper/paper-api/1.20.4-R0.1-SNAPSHOT/'
+          type: 'SNAPSHOT'
+        - name: '1.20.6'
+          path: 'https://repo.papermc.io/repository/maven-public/io/papermc/paper/paper-api/1.20.6-R0.1-SNAPSHOT/'
+          type: 'SNAPSHOT'
+        - name: '1.21'
+          path: 'https://repo.papermc.io/repository/maven-public/io/papermc/paper/paper-api/1.21-R0.1-SNAPSHOT/'
           type: 'SNAPSHOT'
     - name: 'paperlib'
       versions:


### PR DESCRIPTION
horrible code but it works. ~~Test fail somehow no clue why~~, there's also probably a better alternative for Path#toString()

new config option `host-name` added, should be `https://jd.papermc.io`

1.12: `<link rel="canonical" href="https://jd.papermc.io/paper/1.21/org/bukkit/Material.html">`

1.20.6: `<link rel="canonical" href="https://jd.papermc.io/paper/1.21/org/bukkit/Material.html">`

https://discord.com/channels/289587909051416579/1079267380326314125/1261608015203795018
![Discord_0SGFyCBqPc](https://github.com/user-attachments/assets/20fbcdf6-ccd1-42fc-8331-9abc38b0c49e)
